### PR TITLE
Feature/extend command support 2

### DIFF
--- a/syntaxes/escoria.tmLanguage.json
+++ b/syntaxes/escoria.tmLanguage.json
@@ -1,119 +1,134 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "Escoria",
-	"patterns": [
-		{
-			"include": "#state_commands"
-		},
-		{
-			"include": "#item_commands"
-		},
-		{
-			"include": "#other_commands"
-		},
-		{
-			"include": "#keywords"
-		},
-		{
-			"include": "#comments"
-		},
-		{
-			"include": "#strings"
-		},
-		{
-			"include": "#boolean"
-		},
-		{
-			"include": "#numeric"
-		},
-		{
-			"include": "#events"
-		},
-		{
-			"include": "#condition"
-		},
-		{
-			"include": "#dialog"
-		}
-	],
-	"repository": {
-		"state_commands": {
-			"patterns": [{
-				"name": "keyword.control.escoria",
-				"match": "\\b(set_global|set_globals|set_state|set_active)\\b"
-			}]
-		},
-		"item_commands": {
-			"patterns": [{
-				"name": "keyword.control.escoria",
-				"match": "\\b(say|anim|cut_scene|teleport|teleport_pos|walk|walk_block|inventory_add|inventory_remove_and_collide|inventory_open)\\b"
-			}]
-		},
-		"other_commands": {
-			"patterns": [{
-				"name": "keyword.control.escoria",
-				"match": "\\b(debug|wait|change_scene|spawn|stop|restart|sched_event|camera_set_position|camera_set_target|game_over|repeat|queue_resource|queue_animation|queue_scene|jump|autosave)\\b"
-			}]
-		},
-		"keywords": {
-			"patterns": [{
-				"name": "keyword.control.escoria",
-				"match": "\\b(bg_music)\\b"
-			}]
-		},
-		"comments": {
-			"name": "comment.line.dnumber-sign.escoria",
-			"begin": "#",
-			"end": "$"
-		},
-		"strings": {
-			"name": "string.quoted.double.escoria",
-			"begin": "\"",
-			"end": "\"",
-			"patterns": [{
-					"name": "constant.character.escape.escoria",
-					"match": "\\\\."
-				}]
-		},
-		"boolean": {
-			"patterns": [{
-				"name": "constant.language.escoria",
-				"match": "\\b(true|false)\\b"
-			}]
-		},
-		"numeric": {
-			"name": "constant.numeric.escoria",
-			"match": "\\b[+-]?(\\d*\\.)?\\d\\b"
-		},
-		"events": {
-			"name": "constant.character.escape.escoria",
-			"begin": "^:",
-			"end":"\\w+"
-		},
-		"condition": {
-			"name": "keyword.control.escoria",
-			"begin": "\\[",
-			"end": "\\]",
-			"patterns": [{
-					"name": "variable",
-					"match": "[A-Za-z]"
-			}]
-		},
-		"dialog": {
-			"patterns": [{
-					"name": "keyword.control.dialog.escoria",
-					"match": "(^(\\s+)?\\?)"
-			},
-			{
-				"name": "keyword.control.group.escoria",
-				"match": "(^(\\s+)?\\>)"
-			},
-			{
-				"name": "keyword.control.branch.escoria",
-				"match": "(^(\\s+)?\\-)"
-			}	]
-		}
-	},
-	
-	"scopeName": "source.escoria"
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "name": "Escoria",
+    "patterns": [
+        {
+            "include": "#state_commands"
+        },
+        {
+            "include": "#item_commands"
+        },
+        {
+            "include": "#other_commands"
+        },
+        {
+            "include": "#keywords"
+        },
+        {
+            "include": "#comments"
+        },
+        {
+            "include": "#strings"
+        },
+        {
+            "include": "#boolean"
+        },
+        {
+            "include": "#numeric"
+        },
+        {
+            "include": "#events"
+        },
+        {
+            "include": "#condition"
+        },
+        {
+            "include": "#dialog"
+        }
+    ],
+    "repository": {
+        "state_commands": {
+            "patterns": [
+                {
+                    "name": "keyword.control.escoria",
+                    "match": "\\b(set_global|set_globals|set_state|set_active)\\b"
+                }
+            ]
+        },
+        "item_commands": {
+            "patterns": [
+                {
+                    "name": "keyword.control.escoria",
+                    "match": "\\b(say|anim|cut_scene|teleport|teleport_pos|walk|walk_block|inventory_add|inventory_remove_and_collide|inventory_open)\\b"
+                }
+            ]
+        },
+        "other_commands": {
+            "patterns": [
+                {
+                    "name": "keyword.control.escoria",
+                    "match": "\\b(debug|wait|change_scene|spawn|stop|restart|sched_event|camera_set_pos|camera_set_position|camera_set_target|game_over|repeat|queue_resource|queue_animation|queue_scene|jump|autosave)\\b"
+                }
+            ]
+        },
+        "keywords": {
+            "patterns": [
+                {
+                    "name": "keyword.control.escoria",
+                    "match": "\\b(bg_music)\\b"
+                }
+            ]
+        },
+        "comments": {
+            "name": "comment.line.dnumber-sign.escoria",
+            "begin": "#",
+            "end": "$"
+        },
+        "strings": {
+            "name": "string.quoted.double.escoria",
+            "begin": "\"",
+            "end": "\"",
+            "patterns": [
+                {
+                    "name": "constant.character.escape.escoria",
+                    "match": "\\\\."
+                }
+            ]
+        },
+        "boolean": {
+            "patterns": [
+                {
+                    "name": "constant.language.escoria",
+                    "match": "\\b(true|false)\\b"
+                }
+            ]
+        },
+        "numeric": {
+            "name": "constant.numeric.escoria",
+            "match": "\\b[+-]?(\\d*\\.)?\\d\\b"
+        },
+        "events": {
+            "name": "constant.character.escape.escoria",
+            "begin": "^:",
+            "end": "\\w+"
+        },
+        "condition": {
+            "name": "keyword.control.escoria",
+            "begin": "\\[",
+            "end": "\\]",
+            "patterns": [
+                {
+                    "name": "variable",
+                    "match": "[A-Za-z]"
+                }
+            ]
+        },
+        "dialog": {
+            "patterns": [
+                {
+                    "name": "keyword.control.dialog.escoria",
+                    "match": "(^(\\s+)?\\?)"
+                },
+                {
+                    "name": "keyword.control.group.escoria",
+                    "match": "(^(\\s+)?\\>)"
+                },
+                {
+                    "name": "keyword.control.branch.escoria",
+                    "match": "(^(\\s+)?\\-)"
+                }
+            ]
+        }
+    },
+    "scopeName": "source.escoria"
 }

--- a/syntaxes/escoria.tmLanguage.json
+++ b/syntaxes/escoria.tmLanguage.json
@@ -46,13 +46,13 @@
 		"item_commands": {
 			"patterns": [{
 				"name": "keyword.control.escoria",
-				"match": "\\b(say|anim|cut_scene|teleport|walk|walk_block)\\b"
+				"match": "\\b(say|anim|cut_scene|teleport|teleport_pos|walk|walk_block|inventory_add|inventory_remove_and_collide|inventory_open)\\b"
 			}]
 		},
 		"other_commands": {
 			"patterns": [{
 				"name": "keyword.control.escoria",
-				"match": "\\b(debug|wait|change_scene|spawn|stop|restart|sched_event|camera_set_pos|camera_set_target|game_over)\\b"
+				"match": "\\b(debug|wait|change_scene|spawn|stop|restart|sched_event|camera_set_position|camera_set_target|game_over|repeat|queue_resource|queue_animation|queue_scene|jump|autosave)\\b"
 			}]
 		},
 		"keywords": {
@@ -70,12 +70,10 @@
 			"name": "string.quoted.double.escoria",
 			"begin": "\"",
 			"end": "\"",
-			"patterns": [
-				{
+			"patterns": [{
 					"name": "constant.character.escape.escoria",
 					"match": "\\\\."
-				}
-			]
+				}]
 		},
 		"boolean": {
 			"patterns": [{
@@ -88,37 +86,32 @@
 			"match": "\\b[+-]?(\\d*\\.)?\\d\\b"
 		},
 		"events": {
-			"name": "action.control.escoria",
-			"begin": ":",
-			"end": "$",
-			"patterns": [
-				{
-					"name": "constant.character.escape.escoria",
-					"match": "[A-Za-z]"
-				}
-			]
+			"name": "constant.character.escape.escoria",
+			"begin": "^:",
+			"end":"\\w+"
 		},
 		"condition": {
 			"name": "keyword.control.escoria",
 			"begin": "\\[",
 			"end": "\\]",
-			"patterns": [
-				{
+			"patterns": [{
 					"name": "variable",
 					"match": "[A-Za-z]"
-				}
-			]
+			}]
 		},
 		"dialog": {
-			"name": "keyword.control.escoria",
-			"begin": "\\?",
-			"end": "$",
-			"patterns": [
-				{
-					"name": "variable",
-					"match": "[A-Za-z]"
-				}
-			]
+			"patterns": [{
+					"name": "keyword.control.dialog.escoria",
+					"match": "(^(\\s+)?\\?)"
+			},
+			{
+				"name": "keyword.control.group.escoria",
+				"match": "(^(\\s+)?\\>)"
+			},
+			{
+				"name": "keyword.control.branch.escoria",
+				"match": "(^(\\s+)?\\-)"
+			}	]
 		}
 	},
 	


### PR DESCRIPTION
Added support for the missing commands listed either in the documentation "[esc_reference.md](https://github.com/godotengine/escoria/blob/esc2-godot3.2/doc/esc_reference.md)" and the "[vm_level.gd](https://github.com/godotengine/escoria/blob/esc2-godot3.2/device/globals/vm_level.gd)" script file. 